### PR TITLE
Notificaciones solo por email

### DIFF
--- a/backend_django/notifications/models.py
+++ b/backend_django/notifications/models.py
@@ -4,21 +4,11 @@ from django.db import models
 
 
 class Notificacion(models.Model):
-    class OpcionesCanal(models.TextChoices):
-         EMAIL = 'EMAIL', 'Email'
-         SMS = 'SMS', 'SMS'
-         WHATSAPP = "WHATSAPP", 'WhatsApp'
-
     class OpcionesEstado(models.TextChoices):
          PENDIENTE = 'PENDIENTE', 'Pendiente'
          ENVIADA = 'ENVIADA', 'Enviada'
          FALLIDA = "FALLIDA", 'Fallida'      
          
-    canal = models.CharField(
-        max_length=12,
-        choices=OpcionesCanal.choices,
-        default=OpcionesCanal.EMAIL        
-    )    
     mensaje = models.TextField()
     fecha_envio = models.DateTimeField(auto_now_add=True)
     estado = models.CharField(
@@ -26,7 +16,10 @@ class Notificacion(models.Model):
         choices=OpcionesEstado.choices,
         default=OpcionesEstado.PENDIENTE
     )
-    reserva = models.ForeignKey("bookings.Reserva", on_delete=models.CASCADE, related_name="notificaciones")
+    reserva = models.ForeignKey(
+        "bookings.Reserva", 
+        on_delete=models.CASCADE, 
+        related_name="notificaciones")
     
     def __str__(self):
         return f"Notificación: {self.id} | Canal: {self.canal} | Estado: {self.estado} | Reserva: {self.reserva_id}"

--- a/backend_django/notifications/utils.py
+++ b/backend_django/notifications/utils.py
@@ -1,7 +1,7 @@
 from bookings.models import Reserva
 from notifications.models import Notificacion
 
-def crear_notificacion_reserva(reserva, canal=Notificacion.OpcionesCanal.EMAIL):
+def crear_notificacion_reserva(reserva):
     if reserva.estado == Reserva.OpcionesEstado.CONFIRMADA:
         mensaje = f"Tu reserva con ID {reserva.id} ha sido confirmada."
     elif reserva.estado == Reserva.OpcionesEstado.RECHAZADA:
@@ -12,7 +12,6 @@ def crear_notificacion_reserva(reserva, canal=Notificacion.OpcionesCanal.EMAIL):
     
     notificacion = Notificacion.objects.create(
         reserva=reserva,
-        canal=canal,
         estado=Notificacion.OpcionesEstado.PENDIENTE,
         mensaje=mensaje,
     )


### PR DESCRIPTION
## 📌 Cual es tu desarrollo?

Dejamos que solo se envíen notificaciones por email. Habría que plantear si es necesario recoger el teléfono de los clilentes si en realidad no lo vamos a usar y no viene especificado en el enunciado el ejercicio.

## 📸 Screenshots (si aplica)

Agrega las screenshots, es mejor si hay ejemplos visuales.

---

## ✅ De que tipo es esta tarea?

- [x] Feature
- [ ] Bug
- [ ] Documentacion
